### PR TITLE
Be less verbose when no actual fall back is taking place

### DIFF
--- a/trampoline.mjs
+++ b/trampoline.mjs
@@ -40,7 +40,7 @@ async function tryOverrideCache() {
         return;
     }
 
-    // Try Cirrus Runners regional-local cache servers
+    // Try Cirrus Runners region-local cache servers
     const httpCacheHost = process.env["CIRRUS_HTTP_CACHE_HOST"];
 
     if (httpCacheHost) {

--- a/trampoline.mjs
+++ b/trampoline.mjs
@@ -40,9 +40,7 @@ async function tryOverrideCache() {
         return;
     }
 
-    // Fall back to Cirrus Runners regional-local cache servers
-    console.log("Falling back to Cirrus Runners regional-local cache servers...");
-
+    // Try Cirrus Runners regional-local cache servers
     const httpCacheHost = process.env["CIRRUS_HTTP_CACHE_HOST"];
 
     if (httpCacheHost) {


### PR DESCRIPTION
...and we're just running on GitHub-hosted runners.